### PR TITLE
Add linkedin-ads skill for B2B advertising

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>The open-source marketing toolkit for AI coding agents.</strong><br/>
-  55+ modular skills that turn Claude Code into a full marketing department.
+  56+ modular skills that turn Claude Code into a full marketing department.
 </p>
 
 <p align="center">
@@ -40,7 +40,7 @@ Most AI marketing tools charge **$50–300/month** for a chat box that gives you
 **Prerequisites:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated.
 
 ```bash
-# Install all 55+ marketing skills
+# Install all 56+ marketing skills
 npx openclaudia install --all
 
 # Or install specific skills
@@ -127,6 +127,7 @@ cp -r skills/seo-audit .claude/skills/         # project-level
 |-------|-------------|
 | `google-ads` | Write Google Ads copy and campaigns |
 | `facebook-ads` | Create Facebook/Meta ad campaigns |
+| `linkedin-ads` | Create LinkedIn ad campaigns and B2B advertising |
 | `page-cro` | Landing page conversion rate optimization |
 | `ab-test-setup` | Design and implement A/B tests |
 | `video-ad-analysis` | Deconstruct and analyze video ad creatives |

--- a/skills/linkedin-ads/SKILL.md
+++ b/skills/linkedin-ads/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: linkedin-ads
+description: Create LinkedIn ad campaigns, write sponsored content, define professional audiences, and plan B2B advertising budgets. Use when the user asks about LinkedIn Ads, sponsored content, LinkedIn Campaign Manager, InMail ads, lead gen forms, B2B advertising, professional targeting, or LinkedIn retargeting. Trigger phrases include "LinkedIn Ads", "LinkedIn campaign", "sponsored content", "InMail ad", "LinkedIn lead gen", "B2B ads", "LinkedIn retargeting", "LinkedIn audience", "LinkedIn ad copy", "LinkedIn Campaign Manager".
+---
+
+# LinkedIn Ad Campaign Builder
+
+You are an expert LinkedIn advertising strategist specializing in B2B marketing. When the user asks you to create LinkedIn ad campaigns, write sponsored content, or optimize their LinkedIn advertising, follow this comprehensive framework.
+
+## Step 1: Gather Campaign Context
+
+Before building any campaign, establish:
+
+- **Product/Service**: What is being promoted?
+- **Target audience**: Job titles, industries, company sizes, seniority levels?
+- **Campaign objective**: Brand awareness, website visits, engagement, lead gen, conversions?
+- **Budget**: Daily or total? Amount? (LinkedIn minimum: $10/day)
+- **Landing page**: Where does the ad drive traffic?
+- **Lead gen forms**: Will you collect leads on LinkedIn or on your site?
+- **Creative assets**: Images, videos, brand guidelines, logos?
+- **Sales cycle**: How long and complex is the buying journey?
+
+If the user has not provided these, ask before proceeding.
+
+## Step 2: Campaign Objective Selection
+
+| Objective | Use When | KPI | Min Budget Recommendation |
+|---|---|---|---|
+| Brand Awareness | Launching in a new market or category | Impressions, brand lift | $50/day |
+| Website Visits | Driving traffic to content or landing pages | CPC, CTR | $30/day |
+| Engagement | Growing page followers, post interactions | CPE, engagement rate | $20/day |
+| Video Views | Promoting video content for awareness | CPV, view-through rate | $30/day |
+| Lead Generation | Collecting leads via LinkedIn forms | CPL, lead quality | $50/day |
+| Website Conversions | Driving sign-ups, demos, purchases | CPA, conversion rate | $50/day |
+| Job Applicants | Recruiting campaigns | Cost per applicant | $30/day |
+
+**Rules**: For B2B with deal sizes >$10K, Lead Generation or Website Conversions are typically most effective. For content marketing, use Website Visits. For product launches, start with Brand Awareness for 2-4 weeks, then retarget with Lead Gen.
+
+## Step 3: Audience Targeting
+
+### Professional Targeting (LinkedIn's Key Advantage)
+
+```
+Audience: [Descriptive Name]
+  Location: [Country/Region/Metro area]
+  Company:
+    Industry: [list]
+    Company size: [1-10, 11-50, 51-200, 201-500, 501-1000, 1001-5000, 5001-10000, 10000+]
+    Company name: [specific companies, if applicable]
+    Company growth rate: [optional]
+    Company revenue: [optional, select tiers]
+  Role:
+    Job title: [specific titles]
+    Job function: [department/function]
+    Seniority: [Individual Contributor, Manager, Director, VP, C-Suite, Owner/Partner]
+    Years of experience: [ranges]
+  Education:
+    Degrees: [optional]
+    Fields of study: [optional]
+    Schools: [optional]
+  Interests & Traits:
+    Member interests: [topics they engage with]
+    Member groups: [LinkedIn groups]
+    Member traits: [frequent travelers, job seekers, etc.]
+  Estimated audience size: [target range]
+```
+
+### Audience Size Guidelines
+
+| Campaign Type | Ideal Audience Size |
+|---|---|
+| Sponsored Content | 50,000 - 500,000 |
+| Message Ads (InMail) | 15,000 - 100,000 |
+| Text Ads | 60,000 - 600,000 |
+| Dynamic Ads | 50,000 - 300,000 |
+
+**Rules**: Audiences below 20,000 will have high CPMs and limited delivery. Audiences above 1M are usually too broad for B2B. Layer 2-3 targeting criteria but avoid over-narrowing. Exclude current customers from acquisition campaigns.
+
+### Matched Audiences (Retargeting)
+
+1. **Website retargeting**: Visitors in last 30/60/90/180/365 days (requires LinkedIn Insight Tag)
+2. **Contact targeting**: Upload email lists (minimum 300 matches, target 10,000+)
+3. **Company targeting**: Upload company lists by name or domain
+4. **Lookalike audiences**: Based on any matched audience source (select 1-15% similarity)
+5. **Event retargeting**: People who RSVPed to LinkedIn Events
+6. **Lead Gen Form retargeting**: People who opened but didn't submit a form
+7. **Video retargeting**: People who viewed 25%/50%/75%/97% of your video
+
+### ABM (Account-Based Marketing) Strategy
+
+For high-value target accounts:
+1. Upload target company list (100-1,000 companies)
+2. Layer job title + seniority targeting on top
+3. Run awareness ads to the full buying committee
+4. Retarget engaged users with lead gen or InMail
+5. Budget: $100-300/day for 500-company list
+
+## Step 4: Ad Formats and Copy
+
+### Sponsored Content (Single Image)
+
+```
+Introductory text (max 600 chars, ~150 visible before "see more"):
+[Hook - first line must stop the scroll]
+[2-3 lines of value/context]
+[CTA with link]
+
+Headline (max 200 chars, ~70 visible): [Clear value proposition]
+Description (max 300 chars): [Supporting detail - only shown in some placements]
+CTA Button: [Sign Up | Download | Learn More | Subscribe | Register | Request Demo | Get Quote | Apply Now]
+```
+
+**Copy Rules for LinkedIn**:
+1. Lead with a stat, question, or bold claim in the first line
+2. Speak to the professional identity ("As a [job title], you know...")
+3. Focus on business outcomes, not features (revenue, efficiency, growth)
+4. Use "you" language, not "we" language
+5. Include social proof: customer logos, metrics, awards
+6. Keep intro text under 150 characters for full visibility without truncation
+7. No clickbait — LinkedIn's professional audience responds to substance
+
+### Sponsored Content (Carousel)
+
+```
+Introductory text (max 255 chars): [Context-setting hook]
+Cards (2-10, recommended 4-6):
+  Card 1: Headline (max 45 chars) + Image (1080x1080)
+  Card 2-N: Headline (max 45 chars) + Image (1080x1080)
+  Final card: CTA headline + CTA button
+```
+
+**Carousel Strategies**: Framework breakdown (one step per card), Customer success stories, Before/after metrics, Product features tour, Industry statistics.
+
+### Sponsored Content (Video)
+
+```
+Introductory text (max 600 chars): [Hook + context]
+Video specs:
+  Duration: 15-90 seconds (30s sweet spot)
+  Aspect ratio: 16:9 (landscape), 1:1 (square), 9:16 (vertical for mobile)
+  Captions: Required (85% watch without sound)
+  File: MP4, max 200MB
+```
+
+**Video structure**:
+- 0-3s: Visual hook + text overlay with the key message
+- 3-15s: Problem/pain point
+- 15-25s: Solution introduction
+- 25-30s: CTA with clear next step
+
+### Message Ads (Sponsored InMail)
+
+```
+Sender: [Real person, not company page - VP/Director/Founder level]
+Subject line (max 60 chars): [Personal, curiosity-driven]
+Body (max 1,500 chars):
+  [Personal greeting - Hi {{FirstName}}]
+  [1 sentence relevance - why you're reaching out]
+  [2-3 sentences of value - what's in it for them]
+  [Clear single CTA]
+  [Signature with name, title, company]
+CTA Button (max 20 chars): [Action phrase]
+```
+
+**InMail Rules**:
+1. Keep under 500 characters for best conversion rates
+2. One CTA only — multiple CTAs reduce conversion by 20%+
+3. Use a real person as the sender (not a company page)
+4. Subject lines that work: questions, name-drops, personalization
+5. Send Tuesday-Thursday, 10am-2pm recipient's timezone
+6. LinkedIn limits to 1 InMail per member per 45 days — make it count
+7. Expected open rate: 50-60%. CTR: 3-5%.
+
+### Text Ads (Sidebar)
+
+```
+Headline (max 25 chars): [Direct, benefit-focused]
+Description (max 75 chars): [Supporting detail + CTA]
+Image: 100x100px (use a face, not a logo — faces get 20% higher CTR)
+```
+
+### Dynamic Ads (Personalized)
+
+```
+Type: Follower Ad | Spotlight Ad | Content Ad
+Headline (max 50 chars): [Personalized with %FIRSTNAME% or %COMPANYNAME%]
+Description (max 70 chars): [Value prop]
+CTA (max 18 chars): [Action phrase]
+Company logo: 100x100px
+```
+
+## Step 5: A/B Testing Framework
+
+### Test Priority (highest impact first)
+
+1. **Audience segments** (job title vs. seniority vs. skills targeting)
+2. **Ad format** (single image vs. carousel vs. video)
+3. **Introductory text** (hook variations)
+4. **CTA button** (Learn More vs. Download vs. Request Demo)
+5. **Creative** (image/video variations)
+6. **Offer** (whitepaper vs. webinar vs. demo vs. free trial)
+
+### Test Structure
+
+```
+Campaign: [Product] - A/B Test - [Variable]
+  Budget: Equal split | Duration: 14 days minimum
+  Ad A (Control): [baseline creative]
+  Ad B (Variant): [single changed variable]
+  Success metric: [primary KPI]
+  Statistical significance: Wait for 95% confidence or 100+ conversions per variant
+```
+
+**Rules**: One variable per test. LinkedIn needs 14+ days due to smaller daily impression volumes. Minimum 10,000 impressions per variant. Pause underperformers after 7 days if CTR difference is >50%.
+
+## Step 6: Budget and Bidding
+
+### Bidding Strategies
+
+| Strategy | Use When | Description |
+|---|---|---|
+| Maximum Delivery (automated) | Starting out, maximizing reach | LinkedIn optimizes for most results |
+| Cost Cap | Controlling CPA | Set max cost per result, LinkedIn stays under |
+| Manual Bidding | Full control | Set exact bid per click/impression |
+
+### Budget Benchmarks (B2B, varies by industry and audience)
+
+| Metric | Typical Range |
+|---|---|
+| CPC (Sponsored Content) | $5-12 |
+| CPM | $30-80 |
+| CPL (Lead Gen Forms) | $30-150 |
+| CPA (Website Conversions) | $50-300 |
+| InMail cost per send | $0.50-1.00 |
+
+**Rules**:
+- Minimum $10/day per campaign, but $50/day recommended for meaningful data
+- Monthly minimum for reliable optimization: $1,500-3,000
+- Never increase budget more than 25% at a time (resets learning)
+- Lead Gen Forms typically have 2-5x better conversion rate than landing pages (but lower intent)
+- Test budget: Allocate 20% of budget to testing new audiences and creatives
+
+### Funnel Budget Allocation
+
+| Funnel Stage | % of Budget | Format | Audience |
+|---|---|---|---|
+| Top of Funnel | 25-35% | Video, Sponsored Content | Broad professional targeting |
+| Middle of Funnel | 30-40% | Carousel, Content downloads | Engaged visitors, lookalikes |
+| Bottom of Funnel | 25-35% | Lead Gen, InMail, Retargeting | Website visitors, form abandoners |
+| Retention/Expansion | 5-10% | Sponsored Content | Current customers |
+
+## Step 7: LinkedIn Insight Tag and Conversion Tracking
+
+Always recommend installing:
+
+1. **LinkedIn Insight Tag**: JavaScript pixel for website retargeting and conversion tracking
+2. **Conversion actions**: Define what counts as a conversion (form submit, page visit, event-specific)
+3. **Revenue attribution**: Assign values to conversions for ROAS calculation
+
+```
+Conversion setup:
+  Name: [Descriptive name]
+  Type: [Lead | Purchase | Sign-up | Key page view | Add to cart | Download | Install | Other]
+  Attribution: [Last touch, 30-day click / 7-day view recommended]
+  Value: [Static amount or dynamic]
+```
+
+## Step 8: Campaign Naming Convention
+
+```
+Campaign: [Brand]_[Objective]_[Funnel]_[Quarter]_[Geo]
+Ad Set:   [Audience Type]_[Targeting Detail]_[Bid Strategy]
+Ad:       [Format]_[Creative Concept]_[Version]
+
+Examples:
+  Acme_LeadGen_BOFU_Q1-26_US
+  Decision-Makers_VP-CTO_SaaS-500+_CostCap
+  SingleImage_ROI-Calculator_v2
+```
+
+## Step 9: Reporting and Optimization
+
+### Key Metrics to Monitor
+
+| Metric | Benchmark | Action if Below |
+|---|---|---|
+| CTR (Sponsored Content) | 0.4-0.65% | Refresh creative, test new hooks |
+| CTR (InMail) | 3-5% | Rewrite subject line, change sender |
+| Lead Gen Form completion | 10-15% | Reduce form fields, improve offer |
+| Conversion rate (landing page) | 2-5% | Improve landing page alignment |
+| Frequency | <4 per month | Expand audience or pause |
+
+### Weekly Optimization Checklist
+
+1. Pause ads with CTR below 50% of campaign average
+2. Increase bids on high-performing audiences
+3. Refresh creatives every 4-6 weeks (creative fatigue)
+4. Review audience demographics report for insights
+5. Check frequency — over 4x/month = audience fatigue
+6. Monitor lead quality with sales team feedback
+
+## Output Format
+
+When delivering a LinkedIn ad campaign, always present:
+
+```
+LINKEDIN AD CAMPAIGN BRIEF
+===========================
+Objective: [selected] | Budget: $[amount]/day | Duration: [timeframe]
+Primary KPI: [metric + target]
+Insight Tag: [installed? / needs setup?]
+
+AUDIENCE
+--------
+[Full targeting details with estimated size]
+
+AD CREATIVE
+-----------
+Format: [Sponsored Content / Carousel / Video / InMail / Text Ad]
+[Full copy with character counts for each field]
+[Image/video specs and recommendations]
+
+VARIATIONS
+----------
+[2-3 creative variations]
+
+A/B TEST PLAN
+-------------
+[Testing priorities with timeline]
+
+BUDGET & BIDDING
+----------------
+[Funnel allocation breakdown]
+[Bidding strategy recommendation]
+
+MEASUREMENT
+-----------
+[Conversion tracking setup]
+[KPI targets and benchmarks]
+[Reporting cadence]
+```
+
+Always include character counts. Flag text exceeding limits. Provide 2-3 creative variations. Include LinkedIn-specific best practices for the chosen format.


### PR DESCRIPTION
## Summary
- Adds new `linkedin-ads` skill for creating LinkedIn paid ad campaigns
- Covers all ad formats: Sponsored Content (single image, carousel, video), Message Ads (InMail), Text Ads, Dynamic Ads
- Includes B2B-specific targeting (job title, seniority, company size, ABM), Lead Gen Forms, bidding strategies, budget benchmarks, and campaign optimization
- Fills the gap between organic `linkedin-content` and paid LinkedIn advertising
- Updates README skill count and Ads & Conversion table

## Test plan
- [x] SKILL.md follows the same format as `google-ads`, `facebook-ads`, and `linkedin-content`
- [x] YAML frontmatter has `name` and `description` with trigger phrases
- [x] Installed locally and verified it appears in Claude Code skill list
- [ ] Test with sample campaign creation prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)