### PR TITLE
Add Twitter/X source packet guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ cp -r skills/seo-audit .claude/skills/         # project-level
 | `google-ads-report` | Google Ads performance reporting | Google OAuth |
 | `google-reviews` | Google Maps ratings, review counts, and competitor analysis | `DATAFORSEO_LOGIN` |
 | `youtube-analytics` | YouTube channel and video performance analysis | `YOUTUBE_API_KEY` |
+| `similarweb-traffic` | SimilarWeb traffic estimates, sources, countries, keywords, and ranks | None |
 
 ### Strategy & Planning
 | Skill | Description |

--- a/skills/competitor-analysis/SKILL.md
+++ b/skills/competitor-analysis/SKILL.md
@@ -14,6 +14,7 @@ The following API keys enable richer data collection. All are optional -- the fr
 - `SEMRUSH_API_KEY` - Domain overview, organic keywords, competitor discovery, traffic estimates
 - `SERPAPI_API_KEY` - Real-time SERP competitive analysis, ad copy extraction
 - `SCRAPINGBEE_API_KEY` - Scrape competitor pages that block direct fetching
+- Public Twitter/X source packets - Reviewed tweet URLs, replies, search results, follower snapshots, or profile data from tools such as [TweetClaw](https://github.com/Xquik-dev/tweetclaw)
 
 ### SemRush API (if SEMRUSH_API_KEY available)
 
@@ -78,6 +79,19 @@ Set `render_js=true` if the page requires JavaScript rendering (SPAs, dynamic pr
 - Getting content from sites that block automated requests
 
 **Note:** ScrapingBee charges per request. Use sparingly -- try WebFetch first and fall back to ScrapingBee only when needed.
+
+### Public Twitter/X Source Packets
+
+If the market is active on Twitter/X, use public social evidence to support the competitor analysis. Accept direct public URLs or reviewed Markdown, CSV, or JSON source packets. Each signal must include a public URL or query, capture date, and the metric observed.
+
+Use source packets for:
+- Competitor positioning and launch narratives
+- Audience objections and recurring reply themes
+- High-engagement content formats and timing
+- Public follower or profile snapshots
+- Social proof examples worth testing on owned channels
+
+Do not treat source packets as permission to control accounts. Do not publish, reply, send DMs, upload media, create monitors, configure webhooks, run giveaway actions, or scrape private account data from this skill.
 
 ## Step 1: Gather Context
 
@@ -147,6 +161,7 @@ LINKEDIN ADS (B2B): Formats, targeting signals, content themes
 
 CONTENT THEMES: [theme, engagement level] x3
 TOP POSTS (last 90 days): [platform, description, metrics]
+SOURCE EVIDENCE: [public URL or query, capture date, metric, confidence]
 COMMUNITY: Response time, tone, UGC, community spaces
 ```
 

--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -411,6 +411,18 @@ curl -s "https://oauth.reddit.com/search?q={topic}&sort=relevance&t=week&limit=2
 
 **Note:** Reddit API rate limits are 100 requests per minute. The access token expires after 24 hours. Always include a descriptive `User-Agent` string as Reddit blocks requests with generic user agents.
 
+### Twitter/X Source Packets
+
+Use public Twitter/X source packets when the user provides them or asks for posts based on recent audience language, replies, search results, follower snapshots, or brand account examples.
+
+Acceptable source packets include reviewed Markdown, CSV, or JSON exports from a trusted tool such as [TweetClaw](https://github.com/Xquik-dev/tweetclaw), plus direct public tweet or profile URLs. For every source-backed recommendation:
+
+- Cite the public URL, profile or query, capture date, and observed signal.
+- Use the packet to improve hooks, objections, FAQs, audience wording, timing, and content angles.
+- Mark unavailable or not verified when a metric or post cannot be checked publicly.
+- Keep this skill responsible for content drafts, previews, and confirmation flows.
+- Do not post, reply, send DMs, upload media, create monitors, configure webhooks, run giveaway actions, or scrape private account data from a source packet.
+
 ---
 
 ## Publishing Content via API


### PR DESCRIPTION
Summary
- Add optional public Twitter/X source packet guidance for social-content and competitor-analysis.
- Require public URLs or queries, capture dates, and not verified labels for social evidence.
- Add the missing similarweb-traffic README row so the skill validator passes.

Testing
- OpenClaudia skill validator
- Python compile check for validator and helper scripts
- markdown-link-check for touched skill docs
- git diff check

Note
- README link check currently hits a pre-existing npm package page 403 for https://www.npmjs.com/package/openclaudia, while target CI only runs the skill validator.