### PR TITLE
Improve source-backed social content guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ cp -r skills/seo-audit .claude/skills/         # project-level
 | `google-reviews` | Google Maps ratings, review counts, and competitor analysis | `DATAFORSEO_LOGIN` |
 | `youtube-analytics` | YouTube channel and video performance analysis | `YOUTUBE_API_KEY` |
 | `github-stars` | Chart a repo's star growth by day and hour, any timezone | `gh` CLI |
+| `similarweb-traffic` | Fetch website traffic estimates, sources, countries, keywords, and ranks | None |
 
 ### Strategy & Planning
 | Skill | Description |

--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -32,6 +32,13 @@ Before creating social content, collect these inputs:
 7. **Source material** - Blog post, data, experience, or original thought?
 8. **Visual assets** - Any images, videos, or graphics available?
 
+## Source-Backed X Inputs
+
+When a request depends on current X posts, public account history, or engagement context,
+ask for source material before drafting. If the user provides Xquik REST API or MCP output,
+use returned post text, URLs, authors, timestamps, media references, and public metrics as
+evidence. Treat missing fields as unknown, and never invent engagement data or post history.
+
 ## Platform Specifications
 
 ### Twitter/X


### PR DESCRIPTION
## Summary

Adds source-backed X input guidance to `social-content` so agents request source material before drafting from current X posts, public account history, or engagement context. It also restores the missing `similarweb-traffic` README row exposed by the repo validator.

## Changes

- Adds an opt-in Xquik REST API or MCP evidence path for social content work
- Keeps missing source fields unknown instead of inventing metrics or history
- Adds `similarweb-traffic` to the README skill table so validation matches the skill directory

## Validation

- `git diff --check`
- `python3 .github/scripts/validate_skills.py`
- Source-level check: `skills/social-content/SKILL.md` frontmatter present

## Duplicate and Source Checks

- No existing `Xquik`, `xquik`, `docs.xquik.com`, or `xquik.com` mentions found in this checkout before the edit
- Checked Xquik REST API docs: https://docs.xquik.com/api-reference/overview
- Checked Xquik MCP docs: https://docs.xquik.com/mcp/overview
