### PR TITLE
Add geo-difficulty and geo-analysis skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cp -r skills/seo-audit .claude/skills/         # project-level
 | `programmatic-seo` | Create SEO-optimized pages at scale |
 | `ahrefs-research` | Ahrefs Python SDK for backlinks, keywords, domain ratings, and traffic |
 | `geo-query-finder` | Find which ChatGPT search queries mention a brand (GEO visibility) |
+| `geo-difficulty` | Score keyword ranking difficulty for the AI-search era (page-level UR + AI Overview signal) |
 
 ### Content Writing
 | Skill | Description |
@@ -148,6 +149,7 @@ cp -r skills/seo-audit .claude/skills/         # project-level
 | `github-stars` | Chart a repo's star growth by day and hour, any timezone | `gh` CLI |
 | `similarweb-traffic` | Fetch website traffic estimates, sources, countries, keywords, and ranks | None |
 | `ai-citations-report` | GEO report: which AI-search prompts cite a domain (Google AI Overview + ChatGPT), via Enception's paid API | `ENCEPTION_API_KEY` |
+| `geo-analysis` | Full GEO/SEO client analysis with PDF report (AI visibility, market research, competitors), via Enception's paid API | `ENCEPTION_ANALYSIS_API_KEY` |
 
 ### Strategy & Planning
 | Skill | Description |

--- a/skills/geo-analysis/SKILL.md
+++ b/skills/geo-analysis/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: geo-analysis
+description: "Run a full GEO/SEO client analysis for a domain via the Enception external API — start the analysis, poll its status, and download the PDF report covering AI visibility, market research, and competitors. Use when the user says 'run a client analysis', 'analyze <domain> for GEO', 'GEO analysis for <domain>', or 'check analysis status'."
+---
+
+# GEO Analysis
+
+Run a full GEO/SEO analysis for a domain and get a client-ready PDF report: AI visibility (is the brand recommended by ChatGPT / Google AI), deep market research, and competitor landscape.
+
+Thin wrapper over the Enception client-analysis API. Three operations: **start**, **status**, **report** (plus an optional brand-name correction).
+
+**Disclosure:** contributed by Enception AI and calls Enception's **paid** external API. Docs: https://www.enception.ai/doc/api-client-analysis
+
+## Requirements
+
+- `ENCEPTION_ANALYSIS_API_KEY` — sent as the `x-api-key` header. Contact the Enception team via https://www.enception.ai to obtain one. Rate limit: 10 requests/minute.
+
+## 1. Start
+
+`POST https://www.enception.ai/api/external/client-analysis/start`
+
+Required: `website_url`, `primary_region`, `core_goals`. Sensible defaults: `primary_region=us`, `core_goals=traffic`, `output_language=en`, `competitors=[]`. The API normalizes URLs to a bare domain and rejects IPs. Returns `{ id, message }` — **save the `id`**.
+
+Pick `output_language` from an explicit request first, then the user's conversation language, then the domain TLD (`.cn` → `zh`; otherwise `en`).
+
+```bash
+curl -s -X POST "https://www.enception.ai/api/external/client-analysis/start" \
+  -H "x-api-key: $ENCEPTION_ANALYSIS_API_KEY" -H "Content-Type: application/json" \
+  -d '{"website_url":"https://example.com/","primary_region":"us","competitors":[],"core_goals":"traffic","output_language":"en"}'
+```
+
+Only override `primary_region` / `core_goals` / `competitors` if the user specifies. `core_goals` is free text (e.g. `traffic`, `ranking`). Competitors: `[{"name":"X","domain":"x.com"}, ...]` (max 5). For multiple domains, fire one POST each and collect the ids.
+
+## 2. Status
+
+`POST https://www.enception.ai/api/external/client-analysis/status` with body `{ "id": "<id>" }` and the same `x-api-key` header. Returns `{ status: 'pending' | 'failed' | 'succeeded', progress_percent?, pdf_url? }`.
+
+A full run takes **~20–45 minutes** — the bottleneck is the deep market-research step. Poll on a long interval (minutes, not seconds). `succeeded` ⇒ ready to fetch the report. If a run fails or stalls indefinitely, report that to the user rather than inventing results.
+
+## 3. Report
+
+`GET https://www.enception.ai/api/external/client-analysis/report/<id>` — public, no auth; shareable by id. Works once status is `succeeded` (also serves partial runs).
+
+```bash
+curl -s -o geo-analysis-example.pdf \
+  "https://www.enception.ai/api/external/client-analysis/report/<id>"
+```
+
+Confirm it's a real PDF (`file geo-analysis-example.pdf`), then give the user the file and/or the public URL.
+
+## 4. Fix "zero visibility" (brand-name correction)
+
+`POST https://www.enception.ai/api/external/client-analysis/update-brand` with body `{ "id", "brand_name"?, "alternative_names": [...] }` and the `x-api-key` header.
+
+When a report shows zero/low AI visibility but the brand IS recommended by ChatGPT/Google, it's almost always because the brand is only known by its fused domain label (e.g. `pudurobotics`) while AI engines say "Pudu Robotics". Supply the real name + aliases and the route recomputes visibility from the already-stored answers (no re-query — fast), then re-fetch the report.
+
+```bash
+curl -s -X POST "https://www.enception.ai/api/external/client-analysis/update-brand" \
+  -H "x-api-key: $ENCEPTION_ANALYSIS_API_KEY" -H "Content-Type: application/json" \
+  -d '{"id":"<id>","brand_name":"Pudu Robotics","alternative_names":["Pudu","PuduBot"]}'
+```
+
+Returns `{ success, mention_rate, overall_score, average_position, analysis_regenerated }`. New analyses resolve the brand name automatically; this is the manual correction path for existing reports.

--- a/skills/geo-difficulty/SKILL.md
+++ b/skills/geo-difficulty/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: geo-difficulty
+description: "Score how hard a keyword is to rank for in the AI-search era — page-level URL Rating of real competitors (not just domain DR), Ahrefs keyword difficulty, and whether a given site already ranks or is cited in Google's AI Overview. Use when the user asks 'how hard is <keyword> to rank', 'geo difficulty for <keyword>', or 'keyword difficulty for <domain>'."
+---
+
+# GEO Difficulty
+
+Score keyword ranking difficulty for the AI-search era. Unlike plain Ahrefs KD or domain DR, this:
+
+- uses **page-level URL Rating (UR)** of the results that actually target the query — so a generic article on a huge domain (e.g. mckinsey.com) stops inflating the score;
+- is **client-relative** — the same SERP is a wall for a no-name site but ~won for a site already ranking or cited in Google's AI Overview;
+- folds in the **AI Overview** citation as a first-class signal.
+
+**Disclosure:** contributed by Enception AI. Backed by the free public API behind https://www.enception.ai/tools/geo-difficulty (`POST https://www.enception.ai/api/tools/geo-difficulty`, no API key). Server-side data comes from Ahrefs and SerpAPI.
+
+## Usage
+
+```bash
+bash scripts/score.sh "ai form real estate" "ai slide legal" --client example.com
+```
+
+- Pass one or more keywords (quote each). Up to 10 per call.
+- `--client <domain>` is optional; add it to get the client-relative verdict (`WON` / `FOOTHOLD` / `NOT RANKING`).
+- `GEO_DIFFICULTY_URL` env var overrides the endpoint (rarely needed).
+
+Or call the API directly:
+
+```bash
+curl -s -X POST https://www.enception.ai/api/tools/geo-difficulty \
+  -H 'content-type: application/json' \
+  -d '{"keywords":["ai presentation maker"],"client":"example.com"}' --max-time 150
+```
+
+## Output columns
+
+- **absolute** — difficulty 0–100 for a brand-new site (`0.35·KD + 0.40·median competitor page-UR + 0.25·targeting%`).
+- **client_verdict / client_diff** — only with `--client`. WON (top-3 or AI-Overview cited), FOOTHOLD (ranks 4–10), NOT RANKING (with the gap to close, credited for the client's DR).
+- **KD** — Ahrefs keyword difficulty; `-` for zero-volume long-tail.
+- **UR** — median page-level URL Rating of the real competitors.
+- **tgt%** — share of the top-10 that actually target the query.
+- **AIO** — `cited` (client in the AI Overview), `Nsrc` (AIO shown, N sources), `none`, or `n/a` (AIO not available for this query).
+- **competitors** — the targeting results with their UR.
+
+## Notes
+
+- The AI Overview leg depends on Google actually showing an AIO for the query (intermittent); it degrades gracefully to `none`/`n/a`.
+- Numbers shift day to day as SERPs and UR change — treat as a current snapshot, not a fixed grade.
+- Each keyword takes a few seconds server-side; keep `--max-time` generous for batches.

--- a/skills/geo-difficulty/scripts/score.sh
+++ b/skills/geo-difficulty/scripts/score.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# GEO Difficulty — call the enception.ai API and print a table.
+# Usage: score.sh "keyword one" "keyword two" ... [--client domain]
+# Endpoint override: GEO_DIFFICULTY_URL (default prod).
+set -euo pipefail
+
+URL="${GEO_DIFFICULTY_URL:-https://www.enception.ai/api/tools/geo-difficulty}"
+CLIENT=""
+KEYWORDS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --client) CLIENT="$2"; shift 2 ;;
+    --client=*) CLIENT="${1#*=}"; shift ;;
+    *) KEYWORDS+=("$1"); shift ;;
+  esac
+done
+
+if [ ${#KEYWORDS[@]} -eq 0 ]; then
+  echo "usage: score.sh \"keyword\" [\"keyword2\" ...] [--client domain]" >&2
+  exit 1
+fi
+
+# Build JSON body with python (safe quoting).
+BODY=$(KW="$(printf '%s\n' "${KEYWORDS[@]}")" CLIENT="$CLIENT" python3 -c '
+import json,os
+kw=[k for k in os.environ["KW"].split("\n") if k.strip()]
+b={"keywords":kw}
+if os.environ.get("CLIENT"): b["client"]=os.environ["CLIENT"]
+print(json.dumps(b))')
+
+curl -s -X POST "$URL" -H 'content-type: application/json' -d "$BODY" --max-time 150 \
+| python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+if "results" not in d:
+    print(json.dumps(d,indent=2)); sys.exit(0)
+hasc=bool(d.get("client"))
+hdr=["keyword","absolute"]+(["client_verdict","client_diff"] if hasc else [])+["KD","demand","UR","tgt%","AIO","competitors"]
+print("\t".join(hdr))
+for r in sorted(d["results"],key=lambda x:-(x["absolute_difficulty"] or 0)):
+    nsrc=len(r["aio_sources"])
+    aio="cited" if r.get("aio_cited") else ("n/a" if not r["aio_available"] else (str(nsrc)+"src" if nsrc else "none"))
+    dem=r.get("demand_score")
+    row=[r["keyword"],str(r["absolute_difficulty"])]
+    if hasc: row+=[str(r.get("verdict")),str(r.get("client_difficulty"))]
+    row+=[("-" if r["kd"] is None else str(r["kd"])),("-" if dem is None else str(dem)),str(r["competition_ur_median"]),str(r["targeting_pct"]),aio,", ".join(r["real_competitors"][:4])]
+    print("\t".join(row))
+'


### PR DESCRIPTION
## Summary

Two GEO skills contributed by **Enception AI** (disclosure stated in each SKILL.md):

- **`geo-difficulty`** — score keyword ranking difficulty for the AI-search era: page-level URL Rating of real competitors (not just domain DR), Ahrefs KD, and AI Overview citation as a first-class signal. Backed by the **free, keyless** public API behind enception.ai/tools/geo-difficulty. Ships a `scripts/score.sh` table formatter.
- **`geo-analysis`** — full GEO/SEO client analysis with a shareable PDF report (AI visibility, market research, competitors). Calls Enception's **paid** external API (`ENCEPTION_ANALYSIS_API_KEY`, listed in the README requirements column). Docs: https://www.enception.ai/doc/api-client-analysis

## Validation

- `python3 .github/scripts/validate_skills.py` — all 71 skills valid, README table matches
- Live test `geo-difficulty`: `scripts/score.sh "best ai slide maker" --client chatslide.ai` returned a scored row (absolute 36.4, verdict NOT RANKING, real competitors with UR)
- Live test `geo-analysis` API: start/status/report endpoints verified against the public doc (auth via x-api-key, 10 req/min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)