### PR TITLE
Separate brand/non-brand (Google) and prospecting/retargeting (Meta) before optimizing

### DIFF
--- a/skills/facebook-ads/SKILL.md
+++ b/skills/facebook-ads/SKILL.md
@@ -143,7 +143,9 @@ Campaign: [Product] - A/B Test - [Variable]
 
 **Rules**: Minimum $10/day per ad set or 2x target CPA. Learning phase needs ~50 conversions in 7 days per ad set. Never increase budget more than 20% at a time.
 
-**Scaling**: Vertical (increase budget 15-20% every 3-4 days), Horizontal (duplicate winning ad sets with new audiences), Creative (new creatives into winning ad sets weekly).
+> **Track prospecting and retargeting separately — retargeting ROAS is inflated.** Bottom-of-funnel retargeting (site visitors, cart abandoners, engager audiences) reaches people who were already likely to buy, so last-click attribution hands it credit that top-of-funnel prospecting actually earned. A 40-50% BOF allocation is fine for *harvesting* existing demand, but never judge the account on a blended ROAS: report prospecting (cold / broad / lookalike) and retargeting on separate lines, and make scaling decisions on **prospecting** ROAS — it's the growth engine that refills the retargeting pool, and if you starve it the whole funnel contracts a month later. Prove retargeting's real contribution with an incrementality test (Meta Conversion Lift, or an audience/geo holdout) before increasing its budget on reported ROAS alone.
+
+**Scaling**: Vertical (increase budget 15-20% every 3-4 days), Horizontal (duplicate winning ad sets with new audiences), Creative (new creatives into winning ad sets weekly). Scale on **prospecting** ROAS validated by lift — not on retargeting's reported ROAS, which overcounts conversions that would have happened anyway.
 
 ## Step 7: Campaign Naming Convention
 

--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -221,9 +221,11 @@ Quality Score is determined by three factors. Optimize each:
 ### Bidding Best Practices
 - Start with Maximize Conversions (no target) for new campaigns
 - Switch to Target CPA after 50+ conversions in 30 days
-- Set Target CPA at 20% above your actual average CPA, then decrease gradually
+- Set Target CPA at 20% above your actual **non-brand** average CPA — not the blended account average (see the brand/non-brand note below) — then decrease gradually
 - Never change bidding strategy and budget simultaneously
 - Allow 2 weeks of learning after any bidding change
+
+> **Separate brand from non-brand before setting any CPA/ROAS target.** Branded search (queries containing the company or product name) is demand *capture* — cheap by construction and largely non-incremental, since those users were already looking for you. Blending it into your account average pulls the target CPA down and makes non-brand look more efficient than it is, so you under-fund the campaigns actually generating new demand. Report brand separately, set targets off **non-brand**, and never treat a low brand CPA as a win unless it's proven with an incrementality (holdout / geo-experiment) test.
 
 ## Output Format
 


### PR DESCRIPTION
## What
Two small additions so the ads skills separate demand capture from demand generation before optimizing:
- `skills/google-ads/SKILL.md`: set Target CPA off **non-brand** average CPA, not the blended account average.
- `skills/facebook-ads/SKILL.md`: track **prospecting vs retargeting** separately and scale on prospecting ROAS.

## Why
- **Google Ads:** "Set Target CPA at 20% above your actual average CPA" blends brand and non-brand. Branded search is demand capture — cheap by construction — so it drags the account average down and makes non-brand look more efficient than it is, under-funding the campaigns that actually generate new demand.
- **Meta:** the funnel table puts 40-50% into bottom-of-funnel retargeting. That's fine for harvesting, but retargeting reaches people already likely to buy, so its ROAS is inflated by conversions that would have happened anyway. Judge the account on a blended ROAS and you'll over-invest in retargeting and starve prospecting — the growth engine that refills the pool.

Both notes point to incrementality (a holdout / Conversion Lift / geo experiment) as the real test of whether brand or retargeting spend is actually causing conversions. I run a paid-search agency (Drak Marketing) and this separation is the difference between scaling growth and scaling demand you already had.

## The change
Two `>` callouts + a couple of qualified lines, in the skills' existing voice. Docs-only, no new dependencies.
